### PR TITLE
[LX-290] Add installation support fot http basic auth dependency

### DIFF
--- a/tmgmt_xtm_connect.info.yml
+++ b/tmgmt_xtm_connect.info.yml
@@ -4,6 +4,7 @@ package: 'Translation Management'
 core_version_requirement: ^9  || ^10
 dependencies:
   - tmgmt:tmgmt
+  - drupal:basic_auth
 configure: entity.tmgmt_translator.collection
 type: module
 php: 7.4


### PR DESCRIPTION
- This is to make sure that the dependency for `HTTP Basic Auth` will be installed before our plugin can be installed

![image](https://github.com/user-attachments/assets/b05b78c2-5f30-46c1-898d-1583b56248cb)
![image](https://github.com/user-attachments/assets/df726d64-173d-4ae1-b796-d6b4afa3fd23)
![image](https://github.com/user-attachments/assets/2613f5d2-24d6-4333-916d-a5543934df33)
![image](https://github.com/user-attachments/assets/9c05d2d3-1c5f-485b-a899-de4447435f0f)
